### PR TITLE
Integrate Playwright for E2E testing.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,47 @@
+name: Playwright Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5.0.0
+
+      - uses: actions/setup-go@v6.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.2.0
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.2.0
+        with:
+          version: 9.12.2
+          run_install: true
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Start docker compose services
+        run: make compose
+
+      - name: Run Playwright tests
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+        run: pnpm run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ sqs-gui
 .vite
 coverage.html
 coverage.out
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ COVHTML   := coverage.html
 build:
 	@go build -ldflags="-s -w" -o ./sqs-gui -trimpath ./cmd/main.go
 
+.PHONY: compose
+compose:
+	@docker compose up -d elasticmq
+
 .PHONY: test
 test:
 	@go test -v ./...

--- a/e2e/create-queue.spec.ts
+++ b/e2e/create-queue.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Create queue page", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(`/create-queue`);
+	});
+
+	test("shows default form state", async ({ page }) => {
+		await expect(page.locator('[data-page="create-queue"]')).toBeVisible();
+		await expect(
+			page.getByRole("heading", { level: 1, name: "Create queue" }),
+		).toBeVisible();
+
+		const nameInput = page.getByLabel("Queue name");
+		const typeSelect = page.getByLabel("Queue type");
+		const dedupCheckbox = page.getByLabel(
+			"Enable content-based deduplication (FIFO only)",
+		);
+
+		await expect(typeSelect).toHaveValue("standard");
+		await expect(dedupCheckbox).toBeDisabled();
+		await expect(dedupCheckbox).not.toBeChecked();
+		await expect(page.getByLabel("Delay seconds")).toHaveAttribute(
+			"placeholder",
+			"0",
+		);
+		await expect(
+			page.getByLabel("Message retention (seconds)"),
+		).toHaveAttribute("placeholder", "345600");
+		await expect(
+			page.getByLabel("Visibility timeout (seconds)"),
+		).toHaveAttribute("placeholder", "30");
+		await expect(page.getByRole("link", { name: "Cancel" })).toHaveAttribute(
+			"href",
+			"/queues",
+		);
+		await expect(nameInput).toBeVisible();
+	});
+
+	test("switching to FIFO enforces suffix and enables deduplication", async ({
+		page,
+	}) => {
+		const nameInput = page.getByLabel("Queue name");
+		const typeSelect = page.getByLabel("Queue type");
+		const dedupCheckbox = page.getByLabel(
+			"Enable content-based deduplication (FIFO only)",
+		);
+
+		await nameInput.fill("orders");
+		await typeSelect.selectOption("fifo");
+
+		await expect(nameInput).toHaveValue("orders.fifo");
+		await expect(dedupCheckbox).toBeEnabled();
+		await expect(dedupCheckbox).not.toBeChecked();
+
+		// Switching to FIFO again should not duplicate the suffix.
+		await nameInput.fill("orders.fifo");
+		await typeSelect.selectOption("fifo");
+		await expect(nameInput).toHaveValue("orders.fifo");
+	});
+
+	test("switching back to Standard strips suffix and disables deduplication", async ({
+		page,
+	}) => {
+		const nameInput = page.getByLabel("Queue name");
+		const typeSelect = page.getByLabel("Queue type");
+		const dedupCheckbox = page.getByLabel(
+			"Enable content-based deduplication (FIFO only)",
+		);
+
+		await nameInput.fill("payments");
+		await typeSelect.selectOption("fifo");
+		await expect(nameInput).toHaveValue("payments.fifo");
+		await expect(dedupCheckbox).toBeEnabled();
+
+		await typeSelect.selectOption("standard");
+
+		await expect(nameInput).toHaveValue("payments");
+		await expect(dedupCheckbox).toBeDisabled();
+		await expect(dedupCheckbox).not.toBeChecked();
+	});
+
+	test("blur re-applies FIFO suffix after manual removal", async ({ page }) => {
+		const nameInput = page.getByLabel("Queue name");
+		const typeSelect = page.getByLabel("Queue type");
+
+		await nameInput.fill("deliveries");
+		await typeSelect.selectOption("fifo");
+		await expect(nameInput).toHaveValue("deliveries.fifo");
+
+		await nameInput.fill("deliveries");
+		await nameInput.blur();
+
+		await expect(nameInput).toHaveValue("deliveries.fifo");
+	});
+
+	test("shows validation error and preserves form values on invalid submit", async ({
+		page,
+	}) => {
+		const nameInput = page.getByLabel("Queue name");
+		await nameInput.fill("invalid-delay");
+
+		await page.getByLabel("Delay seconds").fill("9999");
+		await page.getByLabel("Message retention (seconds)").fill("120");
+		await page.getByLabel("Visibility timeout (seconds)").fill("45");
+		await page.locator("form").evaluate((form) => {
+			(form as HTMLFormElement).noValidate = true;
+		});
+
+		await page.getByRole("button", { name: "Create queue" }).click();
+
+		await expect(
+			page.getByText("Delay seconds must be between 0 and 900", {
+				exact: false,
+			}),
+		).toBeVisible();
+		await expect(nameInput).toHaveValue("invalid-delay");
+		await expect(page.getByLabel("Delay seconds")).toHaveValue("9999");
+		await expect(page.getByLabel("Message retention (seconds)")).toHaveValue(
+			"120",
+		);
+		await expect(page.getByLabel("Visibility timeout (seconds)")).toHaveValue(
+			"45",
+		);
+	});
+
+	test("submits valid form, redirects, and shows success flash", async ({
+		page,
+	}) => {
+		const queueName = `pw-queue-${Date.now()}`;
+		await page.getByLabel("Queue name").fill(queueName);
+		await page.getByLabel("Queue type").selectOption("standard");
+		await page.getByLabel("Delay seconds").fill("1");
+		await page.getByLabel("Message retention (seconds)").fill("120");
+		await page.getByLabel("Visibility timeout (seconds)").fill("30");
+
+		await page.getByRole("button", { name: "Create queue" }).click();
+
+		await expect(page).toHaveURL(
+			new RegExp(`/queues\\?created=${encodeURIComponent(queueName)}`),
+		);
+		await expect(page.locator("[data-queue-flash]")).toContainText(queueName);
+		await expect(
+			page.locator(`[data-queue-row][data-queue-name="${queueName}"]`),
+		).toBeVisible();
+	});
+
+	test("cancel link returns to queue list without submitting", async ({
+		page,
+	}) => {
+		await page.getByRole("link", { name: "Cancel" }).click();
+		await expect(page).toHaveURL(/\/queues$/);
+		await expect(page.locator('[data-page="queues"]')).toBeVisible();
+	});
+});

--- a/e2e/queues-overview.spec.ts
+++ b/e2e/queues-overview.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Queues overview", () => {
+	test("displays the main controls", async ({ page }) => {
+		await page.goto(`/queues`);
+
+		await expect(page.locator('[data-page="queues"]')).toBeVisible();
+		await expect(
+			page.getByRole("heading", { level: 1, name: "Queues" }),
+		).toBeVisible();
+		await expect(
+			page
+				.locator('[data-page="queues"]')
+				.getByRole("link", { name: /Create queue/i }),
+		).toBeVisible();
+		await expect(page.getByLabel("Filter by name")).toBeVisible();
+		await expect(page.locator("[data-queue-table]")).toBeVisible();
+	});
+});

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
 		"lint": "biome lint .",
 		"check": "biome check .",
 		"check:apply": "biome check --write .",
-		"ci": "biome ci ."
+		"ci": "biome ci .",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.2.4",
+		"@playwright/test": "^1.56.1",
+		"@types/node": "^24.10.1",
 		"typescript": "~5.8.3",
 		"vite": "^7.1.7"
 	},

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+	testDir: "./e2e",
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: "html",
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('')`. */
+		baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:8080",
+
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: "on-first-retry",
+	},
+
+	/* Configure projects for major browsers */
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+
+		{
+			name: "firefox",
+			use: { ...devices["Desktop Firefox"] },
+		},
+
+		{
+			name: "webkit",
+			use: { ...devices["Desktop Safari"] },
+		},
+
+		/* Test against mobile viewports. */
+		// {
+		//   name: 'Mobile Chrome',
+		//   use: { ...devices['Pixel 5'] },
+		// },
+		// {
+		//   name: 'Mobile Safari',
+		//   use: { ...devices['iPhone 12'] },
+		// },
+
+		/* Test against branded browsers. */
+		// {
+		//   name: 'Microsoft Edge',
+		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+		// },
+		// {
+		//   name: 'Google Chrome',
+		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+		// },
+	],
+
+	/* Run your local server before starting the tests. Build assets and boot the Go API. */
+	webServer: {
+		command: `pnpm run build && AWS_SQS_ENDPOINT=${process.env.AWS_SQS_ENDPOINT || "http://localhost:9324"} go run ./cmd/main.go`,
+		url: "http://localhost:8080/queues",
+		reuseExistingServer: !process.env.CI,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.13
-        version: 4.1.13(vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1))
+        version: 4.1.13(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.0)(lightningcss@1.30.1))
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
@@ -18,12 +18,18 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.4
         version: 2.2.4
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.1.7
-        version: 7.1.7(jiti@2.6.0)(lightningcss@1.30.1)
+        version: 7.2.2(@types/node@24.10.1)(jiti@2.6.0)(lightningcss@1.30.1)
 
 packages:
 
@@ -256,6 +262,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.52.2':
     resolution: {integrity: sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==}
     cpu: [arm]
@@ -459,6 +470,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -484,6 +498,11 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -584,6 +603,16 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -617,8 +646,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  vite@7.1.7:
-    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite@7.2.2:
+    resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -799,6 +831,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
+
   '@rollup/rollup-android-arm-eabi@4.52.2':
     optional: true
 
@@ -929,14 +965,18 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.13(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.0)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 7.1.7(jiti@2.6.0)(lightningcss@1.30.1)
+      vite: 7.2.2(@types/node@24.10.1)(jiti@2.6.0)(lightningcss@1.30.1)
 
   '@types/estree@1.0.8': {}
+
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
 
   chownr@3.0.0: {}
 
@@ -979,6 +1019,9 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -1048,6 +1091,14 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  playwright-core@1.56.1: {}
+
+  playwright@1.56.1:
+    dependencies:
+      playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -1103,7 +1154,9 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1):
+  undici-types@7.16.0: {}
+
+  vite@7.2.2(@types/node@24.10.1)(jiti@2.6.0)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1112,6 +1165,7 @@ snapshots:
       rollup: 4.52.2
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 24.10.1
       fsevents: 2.3.3
       jiti: 2.6.0
       lightningcss: 1.30.1


### PR DESCRIPTION
## Summary by Sourcery

キュー UI 向けの Playwright ベースのエンドツーエンドテストを導入し、ローカルおよび CI ワークフローに統合します。

New Features:
- キュー作成ページに対して、バリデーション、FIFO の処理、ナビゲーションフローを含む Playwright エンドツーエンドテストのカバレッジを追加。
- メインのコントロールおよびレイアウトを検証するために、キュー一覧ページ向けの Playwright エンドツーエンドテストのカバレッジを追加。

Build:
- ローカルでブラウザテストを実行するために、Playwright と Node の型の依存関係、および `test:e2e` npm スクリプトを追加。

CI:
- Go、Node、pnpm、Docker サービスを用意し、HTML レポートをアップロードしつつ Playwright テストを実行する GitHub Actions ワークフローを追加。

Tests:
- クロスブラウザテストを実行し、リトライとワーカー数を管理し、テスト実行前に webServer コマンドでアプリを起動する Playwright 設定を導入。
- E2E テストを実行するために必要な Docker サービス（elasticmq）を起動する make compose ターゲットを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Playwright-based end-to-end testing for the queues UI and integrate it into local and CI workflows.

New Features:
- Add Playwright end-to-end test coverage for the create queue page, including validation, FIFO handling, and navigation flows.
- Add Playwright end-to-end test coverage for the queues overview page to verify main controls and layout.

Build:
- Add Playwright and Node type dependencies plus a test:e2e npm script for running browser tests locally.

CI:
- Add a GitHub Actions workflow that provisions Go, Node, pnpm, Docker services, and runs Playwright tests with uploaded HTML reports.

Tests:
- Introduce a Playwright configuration that runs cross-browser tests, manages retries and workers, and boots the app via a webServer command before executing tests.
- Add a make compose target to start required Docker services (elasticmq) for running E2E tests.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Playwright を使ったエンドツーエンドテストを追加（キュー作成フローと一覧画面の主要表示・操作を検証）。

* **Chores**
  * CI ワークフローを追加して E2E テストを実行・HTML レポートを保存。
  * テスト用サービス起動ターゲットを追加。
  * テスト出力／キャッシュを無視する設定、実行スクリプトと開発依存を追加。
  * Playwright のテスト構成とローカルサーバ設定を導入。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->